### PR TITLE
Support for $Header$, include "none" filter

### DIFF
--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -11,3 +11,4 @@ s/\$Author[^\$]*\$/\$Author\$/;
 s/\$Source[^\$]*\$/\$Source\$/; 
 s/\$File[^\$]*\$/\$File\$/; 
 s/\$Revision[^\$]*\$/\$Revision\$/;
+s/\$Commit[^\$]*\$/\$Commit\$/;

--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -11,3 +11,4 @@ s/\$Author[^\$]*\$/\$Author\$/;
 s/\$Source[^\$]*\$/\$Source\$/; 
 s/\$File[^\$]*\$/\$File\$/; 
 s/\$Revision[^\$]*\$/\$Revision\$/;
+s/\$Name[^\$]*\$/\$Name\$/;

--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -11,3 +11,4 @@ s/\$Author[^\$]*\$/\$Author\$/;
 s/\$Source[^\$]*\$/\$Source\$/; 
 s/\$File[^\$]*\$/\$File\$/; 
 s/\$Revision[^\$]*\$/\$Revision\$/;
+s/\$Header[^\$]*\$/\$Header\$/;

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -43,7 +43,8 @@ while (<STDIN>) {
     s/\$Id[^\$]*\$/\$Id: $filename | $date | $name \$/;
     s/\$File[^\$]*\$/\$File:   $filename \$/;
     s/\$Source[^\$]*\$/\$Source: $path \$/;
-	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+    s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+    s/\$Header[^\$]*\$/\$Header: $path $ident $date $name \$/;
 } continue {
     print or die "-p destination: $!\n";
 }

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -36,6 +36,9 @@ $rev =~ /^Date:\s*(.*)\s*$/m;
 $date = $1;
 $rev =~ /^commit (.*)$/m;
 $ident = $1;
+$com = `git log -1 | head -n 1`;
+$com =~ /^commit (.*)$/m;
+$commit = $1;
 
 while (<STDIN>) {
     s/\$Date[^\$]*\$/\$Date:   $date \$/;
@@ -44,6 +47,7 @@ while (<STDIN>) {
     s/\$File[^\$]*\$/\$File:   $filename \$/;
     s/\$Source[^\$]*\$/\$Source: $path \$/;
 	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+	s/\$Commit[^\$]*\$/\$Commit: $commit \$/;
 } continue {
     print or die "-p destination: $!\n";
 }

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -27,6 +27,8 @@ if (0 == length($filename)) {
 }
 
 # Need to grab filename and to use git log for this to be accurate.
+$tag = `git describe --always --tag`;
+chop($tag);
 $rev = `git log -- $path | head -n 3`;
 $rev =~ /^Author:\s*(.*)\s*$/m;
 $author = $1;
@@ -43,7 +45,8 @@ while (<STDIN>) {
     s/\$Id[^\$]*\$/\$Id: $filename | $date | $name \$/;
     s/\$File[^\$]*\$/\$File:   $filename \$/;
     s/\$Source[^\$]*\$/\$Source: $path \$/;
-	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+    s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+    s/\$Name[^\$]*\$/\$Name: $tag \$/;
 } continue {
     print or die "-p destination: $!\n";
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # .gitattributes
 # Map file extensions to git filters
 
+rcs-keywords.* filter=none
 *.h filter=rcs-keywords
 *.c filter=rcs-keywords
 *.cc filter=rcs-keywords

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,4 +1,3 @@
-
 [alias]
 	co = checkout
 	ci = commit -a
@@ -6,6 +5,9 @@
 # To add keyword expansion:
 # git init
 # cp ~/.gitconfig, <project>/.gitattributes, and <project>/.git_filters
+[filter "none"]
+	clean  = cat
+	smudge = cat
 [filter "rcs-keywords"]
 	clean  = .git_filters/rcs-keywords.clean
 	smudge = .git_filters/rcs-keywords.smudge %f

--- a/README
+++ b/README
@@ -1,4 +1,3 @@
-
 This module provides a means to add keyword expansion of the following 
 standard RCS tags to your git projects:
 
@@ -8,6 +7,8 @@ standard RCS tags to your git projects:
 	 $Author$
 	 $Revision$
 	 $Source$
+	 $Name$
+	 $Header$
 
 The mechanism used are filters.  The smudge filter is run on checkout, and the
 clean filter is run on commit.  The tags are only expanded on the local disk,
@@ -18,11 +19,17 @@ To start, you need to add the following to ~/.gitconfig:
 [filter "rcs-keywords"]
 	clean  = .git_filters/rcs-keywords.clean
 	smudge = .git_filters/rcs-keywords.smudge %f
+[filter "none"]
+	clean  = cat
+	smudge = cat
 
 Then, to add keyword expansion, simply add these files to your project:
-    <project>/.gitattributes                    - *.c filter=rcs-keywords
+    <project>/.gitattributes                    - rcs-keywords.* filter=none
+						  *.c filter=rcs-keywords
     <project>/.git_filters/rcs-keywords.smudge  - copy this file to project
     <project>/.git_filters/rcs-keywords.clean   - copy companion to project
+
+Note that without the 'none' filter for the rcs-keywords.* files, if you modify the files, you're basically screwed
 
 Note: This feature is known not to work in git 1.6.2.2 and 1.7.3.*, and 
       verified to work in git 1.7.4.4 and 1.7.4.msysgit.0

--- a/README
+++ b/README
@@ -8,6 +8,7 @@ standard RCS tags to your git projects:
 	 $Author$
 	 $Revision$
 	 $Source$
+	 $Name$         
 
 The mechanism used are filters.  The smudge filter is run on checkout, and the
 clean filter is run on commit.  The tags are only expanded on the local disk,


### PR DESCRIPTION
Support for the do-it-all $Header$ CVS/SVN tag

Also include a "none" filter so you can safely modify the <root>/.git_filters/rcs-keywords.\* without the filter mangling them
