### PR TITLE
major enhancements (complete rewrite and new features):

### DIFF
--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -1,13 +1,42 @@
-#!/usr/bin/perl -p
-#
-# @brief  Git filter to implement rcs keyword expansion as seen in cvs and svn.
-# @author Martin Turon
-#
-# Copyright (c) 2009-2011 Turon Technologies, Inc.  All rights reserved.
+#!/usr/bin/perl
 
-s/\$Id[^\$]*\$/\$Id\$/; 
-s/\$Date[^\$]*\$/\$Date\$/;
-s/\$Author[^\$]*\$/\$Author\$/; 
-s/\$Source[^\$]*\$/\$Source\$/; 
-s/\$File[^\$]*\$/\$File\$/; 
-s/\$Revision[^\$]*\$/\$Revision\$/;
+# commun sub program to generate keyword content
+sub generate_keyword {
+	# pattern as in the raw source file
+	$pattern = $_[0];
+
+	# extract pattern start
+	$start = substr($pattern,0,2);
+	if ($start eq "::") {
+		# if it start with "::", the pattern length must be preserved
+		return "::" . (' ' x (length($pattern) - 2));
+	} else {
+		# return default content without length concern
+		return "";
+	}
+}
+
+# main processing loop
+
+while (<STDIN>) {
+	# replace keyword "Date"
+	s/\$([Dd][Aa][Tt][Ee])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+
+	# replace keyword "Author"
+	s/\$([Aa][Uu][Tt][Hh][Oo][Rr])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+
+	# replace keyword "Id"
+	s/\$([Ii][Dd])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+
+	# replace keyword "Url"
+	s/\$([Uu][Rr][Ll])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+
+	# replace keyword "File"
+	s/\$([Ff][Ii][Ll][Ee])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+
+	# replace keywords "Revision" and "Rev"
+	s/\$([Rr][Ee][Vv][Ii][Ss][Ii][Oo][Nn])([^\$]*)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+	s/\$([Rr][Ee][Vv])([^Ii][^\$]*|)\$/"\$" . $1 . generate_keyword($2) . "\$"/eg;
+} continue {
+	print
+}

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -1,49 +1,80 @@
 #!/usr/bin/perl
-#
-# @brief  Git filter to implement rcs keyword expansion as seen in cvs and svn.
-# @author Martin Turon
-#
-# Usage:
-#    .git_filter/rcs-keywords.smudge file_path < file_contents
-# 
-# To add keyword expansion:
-#    <project>/.gitattributes                    - *.c filter=rcs-keywords
-#    <project>/.git_filters/rcs-keywords.smudge  - copy this file to project
-#    <project>/.git_filters/rcs-keywords.clean   - copy companion to project
-#    ~/.gitconfig                                - add [filter] lines below
-#
-# [filter "rcs-keywords"]
-#	clean  = .git_filters/rcs-keywords.clean
-#	smudge = .git_filters/rcs-keywords.smudge %f
-#
-# Copyright (c) 2009-2011 Turon Technologies, Inc.  All rights reserved.
 
-$path = shift;
-$path =~ /.*\/(.*)/;
-$filename = $1;
+# commun sub program to generate keyword content
+sub generate_keyword {
+	# pattern as in the raw source file
+	$pattern = $_[0];
+	# keyword value from git log
+	$value = $_[1];
 
-if (0 == length($filename)) {
-	$filename = $path;
+	# extract pattern start
+	$start = substr($pattern,0,2);
+	if ($start eq "::") {
+		# if it start with "::", the pattern length must be preserved
+		return ":: " . $value . (' ' x (length($pattern) - length($value) - 3));
+	} else {
+		# return default content without length concern
+		return ": " . $value . " ";
+	}
 }
 
-# Need to grab filename and to use git log for this to be accurate.
-$rev = `git log -- $path | head -n 3`;
-$rev =~ /^Author:\s*(.*)\s*$/m;
-$author = $1;
-$author =~ /\s*(.*)\s*<.*/;
-$name = $1;
-$rev =~ /^Date:\s*(.*)\s*$/m;
-$date = $1;
-$rev =~ /^commit (.*)$/m;
-$ident = $1;
+# get first argument (full path name)
+$path = shift;
 
-while (<STDIN>) {
-    s/\$Date[^\$]*\$/\$Date:   $date \$/;
-    s/\$Author[^\$]*\$/\$Author: $author \$/;
-    s/\$Id[^\$]*\$/\$Id: $filename | $date | $name \$/;
-    s/\$File[^\$]*\$/\$File:   $filename \$/;
-    s/\$Source[^\$]*\$/\$Source: $path \$/;
-	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
-} continue {
-    print or die "-p destination: $!\n";
+if (0 < length($path)) {
+	# extract file name
+	$path =~ /.*\/(.*)/;
+	$filename = $1;
+
+	# not a full path, return the entire path as file name
+	if (0 == length($filename)) {
+		$filename = $path;
+	}
+
+	# Need to grab filename and to use git log for this to be accurate.
+	use IPC::Open3;
+	$pid = open3(0,\*READ,\*ERROR,"git", "log", "-n", "1", "--format=%H%n%an%n%ai%n", "--", "$path");
+	waitpid( $pid, 0 );
+
+	# read error pipe
+	chomp($error = <ERROR>);
+
+	# if there is no error message
+	if (0 == length($error)) {
+		# read the 3 output lines of svn log
+		chomp($revision = <READ>); # 1st line is revision hash
+		chomp($author = <READ>);   # 2nd line is author name
+		chomp($date = <READ>);     # 3rd line is date
+		
+		# some usefull debug stuff
+		# print("$revision\n$author\n$date\n");
+		
+		# main processing loop
+		
+		# read from stdin
+		while (<STDIN>) {
+			# replace keyword "Date"
+			s/\$([Dd][Aa][Tt][Te])([^\$]*)\$/"\$" . $1 . generate_keyword($2,$date) . "\$"/eg;
+
+			# replace keyword "Author"
+			s/\$([Aa][Uu][Tt][Hh][Oo][Rr])([^\$]*)\$/"\$" . $1 . generate_keyword($2,$author) . "\$"/eg;
+
+			# replace keyword "Id"
+			s/\$([Ii][Dd])([^\$]*)\$(.*)/"\$" . $1 . generate_keyword($2,$path . " " . $author . " " . date) . "\$"/eg;
+
+			# replace keyword "Url"
+			s/\$([Uu][Rr][Ll])([^\$]*)\$/"\$" . $1 . generate_keyword($2,$path) . "\$"/eg;
+
+			# replace keyword "File"
+			s/\$([Ff][Ii][Ll][Ee])([^\$]*)\$/"\$" . $1 . generate_keyword($2,$filename) . "\$"/eg;
+
+			# replace keywords "Revision" and "Rev"
+			s/\$([Rr][Ee][Vv][Ii][Ss][Ii][Oo][Nn])([^\$]*)\$/"\$" . $1 . generate_keyword($2,$revision) . "\$"/eg;
+			s/\$([Rr][Ee][Vv])([^Ii][^\$]*|)\$/"\$" . $1 . generate_keyword($2,$revision) . "\$"/eg;
+
+		} continue {
+			# output generated text to stdout
+			print;
+		}
+	}
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 *.cc filter=rcs-keywords
 *.m filter=rcs-keywords
 *.mm filter=rcs-keywords
+*.pas filter=rcs-keywords

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,11 +1,3 @@
-
-[alias]
-	co = checkout
-	ci = commit -a
-
-# To add keyword expansion:
-# git init
-# cp ~/.gitconfig, <project>/.gitattributes, and <project>/.git_filters
 [filter "rcs-keywords"]
-	clean  = .git_filters/rcs-keywords.clean
-	smudge = .git_filters/rcs-keywords.smudge %f
+	clean=.git_filters/rcs-keywords.clean
+	smudge=.git_filters/rcs-keywords.smudge %f

--- a/README
+++ b/README
@@ -7,7 +7,8 @@ standard RCS tags to your git projects:
 	 $File$
 	 $Author$
 	 $Revision$
-	 $Source$
+	 $Rev$
+	 $File$
 
 The mechanism used are filters.  The smudge filter is run on checkout, and the
 clean filter is run on commit.  The tags are only expanded on the local disk,


### PR DESCRIPTION
- work on Windows (no more requirement of Unix "head")
- use IO::Open3 in place of ``: no shell is invoked anymore
- use custom log from git to limit output size and increase efficiency
- support for fixed-length keywords (ie. SVN $Author::     $)
- keep keyword case unchanged in both directions
- support for $Rev$ as well as for $Revision$
