### PR TITLE
A few minor changes to make it work with my SVN-derived source

### DIFF
--- a/.git_filters/rcs-keywords.clean
+++ b/.git_filters/rcs-keywords.clean
@@ -5,9 +5,9 @@
 #
 # Copyright (c) 2009-2011 Turon Technologies, Inc.  All rights reserved.
 
-s/\$Id[^\$]*\$/\$Id\$/; 
-s/\$Date[^\$]*\$/\$Date\$/;
-s/\$Author[^\$]*\$/\$Author\$/; 
-s/\$Source[^\$]*\$/\$Source\$/; 
-s/\$File[^\$]*\$/\$File\$/; 
-s/\$Revision[^\$]*\$/\$Revision\$/;
+s/\$Id(|: [^\$]*)\$/\$Id\$/; 
+s/\$Date(|: [^\$]*)\$/\$Date\$/;
+s/\$Author(|: [^\$]*)\$/\$Author\$/; 
+s/\$Source(|: [^\$]*)\$/\$Source\$/; 
+s/\$File(|: [^\$]*)\$/\$File\$/; 
+s/\$Revision(|: [^\$]*)\$/\$Revision\$/;

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -27,12 +27,12 @@ if (0 == length($filename)) {
 }
 
 # Need to grab filename and to use git log for this to be accurate.
-$rev = `git log -- $path | head -n 3`;
-$rev =~ /^Author:\s*(.*)\s*$/m;
+$rev = `git log -n 1 -- $path | head -n 3`;
+$rev =~ /^Author:\s*(.*?)\s*$/m;
 $author = $1;
-$author =~ /\s*(.*)\s*<.*/;
+$author =~ /\s*(.*?)\s*<.*/;
 $name = $1;
-$rev =~ /^Date:\s*(.*)\s*$/m;
+$rev =~ /^Date:\s*(.*?)\s*$/m;
 $date = $1;
 $rev =~ /^commit (.*)$/m;
 $ident = $1;

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -27,7 +27,7 @@ if (0 == length($filename)) {
 }
 
 # Need to grab filename and to use git log for this to be accurate.
-$rev = `git log -n 1 -- $path | head -n 3`;
+$rev = `git log -n 1 --date=iso -- $path`;
 $rev =~ /^Author:\s*(.*?)\s*$/m;
 $author = $1;
 $author =~ /\s*(.*?)\s*<.*/;
@@ -36,14 +36,16 @@ $rev =~ /^Date:\s*(.*?)\s*$/m;
 $date = $1;
 $rev =~ /^commit (.*)$/m;
 $ident = $1;
+$rev =~ /^    git-svn-id.*@([0-9]+)/m;
+$svnrev = $1 || $ident;
 
 while (<STDIN>) {
     s/\$Date[^\$]*\$/\$Date:   $date \$/;
     s/\$Author[^\$]*\$/\$Author: $author \$/;
-    s/\$Id[^\$]*\$/\$Id: $filename | $date | $name \$/;
+    s/\$Id[^\$]*\$/\$Id: $filename $svnrev $date $name \$/;
     s/\$File[^\$]*\$/\$File:   $filename \$/;
     s/\$Source[^\$]*\$/\$Source: $path \$/;
-	s/\$Revision[^\$]*\$/\$Revision: $ident \$/;
+	s/\$Revision[^\$]*\$/\$Revision: $svnrev \$/;
 } continue {
     print or die "-p destination: $!\n";
 }

--- a/.git_filters/rcs-keywords.smudge
+++ b/.git_filters/rcs-keywords.smudge
@@ -22,11 +22,15 @@ $path = shift;
 $path =~ /.*\/(.*)/;
 $filename = $1;
 
+use DateTime::Format::Strptime;
+
 if (0 == length($filename)) {
 	$filename = $path;
 }
 
 # Need to grab filename and to use git log for this to be accurate.
+# could add --grep=git-svn-id, but shouldn't be necessary
+# -n 1 replaces | head more efficiently and includes entire log message
 $rev = `git log -n 1 --date=iso -- $path`;
 $rev =~ /^Author:\s*(.*?)\s*$/m;
 $author = $1;
@@ -38,12 +42,15 @@ $rev =~ /^commit (.*)$/m;
 $ident = $1;
 $rev =~ /^    git-svn-id.*@([0-9]+)/m;
 $svnrev = $1 || $ident;
+$strp = DateTime::Format::Strptime->new(pattern => '%F %T %z');
+$ldate = $strp->parse_datetime($date)->strftime('(%c)');
+ 
 
 while (<STDIN>) {
-    s/\$Date[^\$]*\$/\$Date:   $date \$/;
+    s/\$Date[^\$]*\$/\$Date: $date $ldate \$/;
     s/\$Author[^\$]*\$/\$Author: $author \$/;
     s/\$Id[^\$]*\$/\$Id: $filename $svnrev $date $name \$/;
-    s/\$File[^\$]*\$/\$File:   $filename \$/;
+    s/\$File[^\$]*\$/\$File: $filename \$/;
     s/\$Source[^\$]*\$/\$Source: $path \$/;
 	s/\$Revision[^\$]*\$/\$Revision: $svnrev \$/;
 } continue {


### PR DESCRIPTION
I use git repositories as public mirrors of my personal SVN.  I use keyword substitution in documents and code.  The patch I'm proposing first fixes a bug (whitespace not being stripped off end; at least I assume it's a bug, since it causes excess whitespace in the output) and makes the git log command more efficient (only dump the first log entry, not every single one).  The second patch additionally parses out the git-svn commit ID and reformats $Id$ and $Date$ to be more like what SVN gives.  This makes latex's rcs package's keyword parser work better.
